### PR TITLE
Reader source constructors

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -26,6 +26,20 @@ pub struct ReaderSource {
 }
 
 impl ReaderSource {
+    pub fn from_reader<P: AsRef<Path>>(
+        reader: Reader<File>,
+        path: P,
+        encoding: EncodingRef,
+    ) -> ReaderSource {
+        ReaderSource {
+            reader,
+            // FIXME: if the path is really needed later, it should be stored as PathBuf,
+            // not a String
+            path: path.as_ref().to_string_lossy().to_string(),
+            encoding,
+        }
+    }
+
     pub fn from_path<P: AsRef<Path>>(path: P, encoding: EncodingRef) -> ReaderSource {
         ReaderSource {
             // FIXME: return an error, don't unwrap

--- a/src/input.rs
+++ b/src/input.rs
@@ -40,9 +40,15 @@ impl ReaderSource {
         }
     }
 
-    pub fn from_path<P: AsRef<Path>>(path: P, encoding: EncodingRef) -> ReaderSource {
-        // FIXME: return an error  from cvs::Reader::from_path(), don't unwrap
-        ReaderSource::from_reader(csv::Reader::from_path(&path).unwrap(), path, encoding)
+    pub fn from_path<P: AsRef<Path>>(
+        path: P,
+        encoding: EncodingRef,
+    ) -> Result<ReaderSource, csv::Error> {
+        Ok(ReaderSource::from_reader(
+            csv::Reader::from_path(&path)?,
+            path,
+            encoding,
+        ))
     }
 
     fn headers(&mut self) -> Row {
@@ -155,7 +161,7 @@ mod tests {
         let filenames = ["test/assets/1.csv", "test/assets/2.csv"];
         let mut input_stream: InputStream = filenames
             .iter()
-            .filter_map(|f| Some(ReaderSource::from_path(f, UTF_8)))
+            .filter_map(|f| Some(ReaderSource::from_path(f, UTF_8).unwrap()))
             .collect();
 
         assert_eq!(
@@ -186,7 +192,7 @@ mod tests {
         let filenames = ["test/assets/windows1252/data.csv"];
         let mut input_stream: InputStream = filenames
             .iter()
-            .filter_map(|f| Some(ReaderSource::from_path(f, WINDOWS_1252)))
+            .filter_map(|f| Some(ReaderSource::from_path(f, WINDOWS_1252).unwrap()))
             .collect();
 
         assert_eq!(*input_stream.headers(), Row::from(vec!["name", "_source"]));

--- a/src/input.rs
+++ b/src/input.rs
@@ -20,9 +20,9 @@ fn decode(data: ByteRecord, encoding: EncodingRef) -> Row {
 }
 
 pub struct ReaderSource {
-    pub reader: Reader<File>,
-    pub path: String,
-    pub encoding: EncodingRef,
+    reader: Reader<File>,
+    path: String,
+    encoding: EncodingRef,
 }
 
 impl ReaderSource {

--- a/src/input.rs
+++ b/src/input.rs
@@ -41,14 +41,8 @@ impl ReaderSource {
     }
 
     pub fn from_path<P: AsRef<Path>>(path: P, encoding: EncodingRef) -> ReaderSource {
-        ReaderSource {
-            // FIXME: return an error, don't unwrap
-            reader: csv::Reader::from_path(&path).unwrap(),
-            // FIXME: if the path is really needed later, it should be stored as PathBuf,
-            // not a String
-            path: path.as_ref().to_string_lossy().to_string(),
-            encoding,
-        }
+        // FIXME: return an error  from cvs::Reader::from_path(), don't unwrap
+        ReaderSource::from_reader(csv::Reader::from_path(&path).unwrap(), path, encoding)
     }
 
     fn headers(&mut self) -> Row {

--- a/src/input.rs
+++ b/src/input.rs
@@ -67,6 +67,16 @@ pub struct ByteRecordsIntoIterSource {
     pub encoding: EncodingRef,
 }
 
+impl ByteRecordsIntoIterSource {
+    pub fn from_source(source: ReaderSource) -> ByteRecordsIntoIterSource {
+        ByteRecordsIntoIterSource {
+            records: source.reader.into_byte_records(),
+            path: source.path.clone(),
+            encoding: source.encoding,
+        }
+    }
+}
+
 pub struct InputStream {
     readers: Vec<ReaderSource>,
     current_records: ByteRecordsIntoIterSource,
@@ -80,11 +90,7 @@ impl InputStream {
         InputStream {
             readers: Vec::new(),
             headers,
-            current_records: ByteRecordsIntoIterSource {
-                path: reader_source.path,
-                records: reader_source.reader.into_byte_records(),
-                encoding: reader_source.encoding,
-            },
+            current_records: ByteRecordsIntoIterSource::from_source(reader_source),
         }
     }
 
@@ -135,11 +141,7 @@ impl Iterator for InputStream {
                         panic!("Inconsistent headers among files");
                     }
 
-                    self.current_records = ByteRecordsIntoIterSource {
-                        path: rs.path,
-                        records: rs.reader.into_byte_records(),
-                        encoding: rs.encoding,
-                    };
+                    self.current_records = ByteRecordsIntoIterSource::from_source(rs);
 
                     self.next()
                 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -62,9 +62,9 @@ impl ReaderSource {
 }
 
 pub struct ByteRecordsIntoIterSource {
-    pub records: ByteRecordsIntoIter<File>,
-    pub path: String,
-    pub encoding: EncodingRef,
+    records: ByteRecordsIntoIter<File>,
+    path: String,
+    encoding: EncodingRef,
 }
 
 impl ByteRecordsIntoIterSource {

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,11 +81,8 @@ fn main() {
     let input_stream: InputStream = filenames
         .iter()
         .filter_map(|f| match csv::Reader::from_path(f) {
-            Ok(reader) => Some(ReaderSource {
-                reader,
-                path: f.to_string(),
-                encoding: encoding,
-            }),
+            Ok(reader) => Some(ReaderSource::from_reader(reader, f, encoding)),
+
             Err(e) => {
                 match e.kind() {
                     csv::ErrorKind::Io(error) => match error.kind() {


### PR DESCRIPTION
This PR adds constructors for `ReaderSource` and `ByteRecordsIntoIterSource`, which in turn lets us make the fields in both of those structs private.